### PR TITLE
Adds versionbit rejection code

### DIFF
--- a/doc/release-notes/release-notes-4.4.0.md
+++ b/doc/release-notes/release-notes-4.4.0.md
@@ -1,0 +1,21 @@
+# NavCoin v4.4.0 Release Notes
+
+## Community Fund:
+
+
+
+## Allow users to reject specific version bits 
+This release introduces the concept of bit version rejection. 
+
+It is designed to make it easier for the network to reject individual soft forks when they are bundled together in 1 release. As soft forks come within the software signaling by default only the converse was needed for people to reject soft forks they did not agree with.
+
+A new config concept has been added called `rejectversionbit`  users can signal all the soft forks they reject by adding the following to the config.
+
+```
+rejectversionbit=15
+rejectversionbit=16
+rejectversionbit=17
+```
+
+
+### Other modifications in the NavCoin client:

--- a/doc/release-notes/release-notes-4.4.0.md
+++ b/doc/release-notes/release-notes-4.4.0.md
@@ -4,7 +4,7 @@
 
 
 
-## Allow users to reject specific version bits 
+## Reject specific version bits 
 This release introduces the concept of bit version rejection. 
 
 It is designed to make it easier for the network to reject individual soft forks when they are bundled together in 1 release. As soft forks come within the software signaling by default only the converse was needed for people to reject soft forks they did not agree with.

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -149,6 +149,7 @@ testScripts = [
     'cfund-vote.py',
     'cfund-proposal-state-accept.py',
     'cfund-proposal-state-expired.py',
+    'reject-version-bit.py',
 ]
 #if ENABLE_ZMQ:
 #    testScripts.append('zmq_test.py')

--- a/qa/rpc-tests/reject-version-bit.py
+++ b/qa/rpc-tests/reject-version-bit.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The NavCoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test rejection of version bit votes
+#
+
+import time
+from test_framework.test_framework import NavCoinTestFramework
+from test_framework.util import *
+from test_framework.mininode import *
+
+class RejectVersionBitTest(NavCoinTestFramework):
+
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 4)
+
+    def setup_network(self):
+        self.nodes = []
+        # Nodes 0/1 are "wallet" nodes
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-rejectversionbit=6"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, []))
+        connect_nodes(self.nodes[0], 1)
+        self.is_network_split = False
+        self.sync_all()
+
+    def run_test(self):
+        print("Mining blocks...")
+        blocks_node_1=self.nodes[0].generate(100)
+        self.sync_all()
+        assert(self.nodes[0].getblockchaininfo()["bip9_softforks"]["segwit"]["status"] == "started")
+        blocks_node_1=self.nodes[0].generate(10)
+        self.sync_all()
+        blocks_node_2=self.nodes[1].generate(90)
+        self.sync_all()
+        assert(self.nodes[0].getblock(blocks_node_1[-1])["version"] & (1<<6) == 0)
+        assert(self.nodes[1].getblock(blocks_node_2[-1])["version"] & (1<<6) == (1<<6))
+        self.sync_all()
+        assert(self.nodes[0].getblockchaininfo()["bip9_softforks"]["segwit"]["status"] == "locked_in")
+        blocks_node_1=self.nodes[0].generate(50)
+        blocks_node_2=self.nodes[1].generate(50)
+        assert(self.nodes[0].getblock(blocks_node_1[-1])["version"] & (1<<6) == (1<<6))
+        assert(self.nodes[1].getblock(blocks_node_2[-1])["version"] & (1<<6) == (1<<6))
+
+if __name__ == '__main__':
+    RejectVersionBitTest().main()

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -422,6 +422,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-port=<port>", strprintf(_("Listen for connections on <port> (default: %u or testnet: %u or devnet: %u)"), Params(CBaseChainParams::MAIN).GetDefaultPort(), Params(CBaseChainParams::TESTNET).GetDefaultPort(), Params(CBaseChainParams::DEVNET).GetDefaultPort()));
     strUsage += HelpMessageOpt("-proxy=<ip:port>", _("Connect through SOCKS5 proxy"));
     strUsage += HelpMessageOpt("-proxyrandomize", strprintf(_("Randomize credentials for every proxy connection. This enables Tor stream isolation (default: %u)"), DEFAULT_PROXYRANDOMIZE));
+    strUsage += HelpMessageOpt("-rejectversionbit=<n>", _("Reject a suggested version bit"));
     strUsage += HelpMessageOpt("-requirednssec", _("Requires DNS Sec for OpenAlias requests (default: true)"));
     strUsage += HelpMessageOpt("-seednode=<ip>", _("Connect to a node to retrieve peer addresses, and disconnect"));
 #ifdef ENABLE_WALLET

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2472,7 +2472,8 @@ int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Para
 
     for (int i = 0; i < (int)Consensus::MAX_VERSION_BITS_DEPLOYMENTS; i++) {
         ThresholdState state = VersionBitsState(pindexPrev, params, (Consensus::DeploymentPos)i, versionbitscache);
-        if (state == THRESHOLD_LOCKED_IN || state == THRESHOLD_STARTED || state == THRESHOLD_ACTIVE) {
+        if ((state == THRESHOLD_LOCKED_IN || state == THRESHOLD_STARTED || state == THRESHOLD_ACTIVE)
+                && !IsVersionBitRejected(params, (Consensus::DeploymentPos)i)) {
             nVersion |= VersionBitsMask(params, (Consensus::DeploymentPos)i);
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2472,8 +2472,8 @@ int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Para
 
     for (int i = 0; i < (int)Consensus::MAX_VERSION_BITS_DEPLOYMENTS; i++) {
         ThresholdState state = VersionBitsState(pindexPrev, params, (Consensus::DeploymentPos)i, versionbitscache);
-        if ((state == THRESHOLD_LOCKED_IN || state == THRESHOLD_STARTED || state == THRESHOLD_ACTIVE)
-                && !IsVersionBitRejected(params, (Consensus::DeploymentPos)i)) {
+        if ((state == THRESHOLD_LOCKED_IN || state == THRESHOLD_ACTIVE  ||
+             (state == THRESHOLD_STARTED && !IsVersionBitRejected(params, (Consensus::DeploymentPos)i)))) {
             nVersion |= VersionBitsMask(params, (Consensus::DeploymentPos)i);
         }
     }

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -136,6 +136,31 @@ public:
 
 }
 
+bool IsVersionBitRejected(const Consensus::Params& params, Consensus::DeploymentPos pos){
+
+    bool isRejected = false;
+
+    std::vector<std::string>& versionBitVotes = mapMultiArgs["-rejectversionbit"];
+
+    int bitTest = params.vDeployments[pos].bit;
+
+     BOOST_FOREACH(std::string rejectedBit, versionBitVotes) {
+         if (isdigit(rejectedBit[0])) {
+
+           int rBit =  stoi(rejectedBit);
+           if(rBit == bitTest) {
+                isRejected = true;
+
+                return isRejected;
+                //LogPrint("versionbits", "Reject version bit: %i \n", rBit);
+           }
+         }
+     }
+
+    return isRejected;
+
+}
+
 ThresholdState VersionBitsState(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos, VersionBitsCache& cache)
 {
     return VersionBitsConditionChecker(pos).GetStateFor(pindexPrev, params, cache.caches[pos]);

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -152,7 +152,7 @@ bool IsVersionBitRejected(const Consensus::Params& params, Consensus::Deployment
                 isRejected = true;
 
                 return isRejected;
-                //LogPrint("versionbits", "Reject version bit: %i \n", rBit);
+
            }
          }
      }

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -101,5 +101,7 @@ struct VersionBitsCache
 
 ThresholdState VersionBitsState(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos, VersionBitsCache& cache);
 uint32_t VersionBitsMask(const Consensus::Params& params, Consensus::DeploymentPos pos);
+bool IsVersionBitRejected(const Consensus::Params& params, Consensus::DeploymentPos pos);
+
 
 #endif


### PR DESCRIPTION
This PR introduces the concept of bit version rejection. 

Please not this is a resubission of https://github.com/aguycalled/navcoin-core/pull/14 with the changes and code spit out as requested!

It is designed to make it easier for the network to reject individual soft forks when they are bundled together in 1 release. As soft forks come within the software signaling by default only the converse was needed for people to reject soft forks they did not agree with.

A new config concept has been added called `rejectversionbit`  users can signal all the soft forks they reject by adding the following to the config

```
rejectversionbit=15
rejectversionbit=16
rejectversionbit=17
```

I built this as a new function in versionbits.cpp as that seemed the most logical place instead of mashing it into the ComputeBlockVersion, I think this will allows some expansion later down the line
