### PR TITLE
Changed proposal expiry status checking.

### DIFF
--- a/src/consensus/cfund.cpp
+++ b/src/consensus/cfund.cpp
@@ -360,12 +360,11 @@ bool CFund::CProposal::IsRejected() const {
 
 bool CFund::CProposal::IsExpired(uint32_t currentTime) const {
     if(nVersion >= 2) {
-        if (mapBlockIndex.count(blockhash) == 0)
-            return (nVotingCycle > Params().GetConsensus().nCyclesProposalVoting && (CanVote() || fState == EXPIRED));
-
-        CBlockIndex* pblockindex = mapBlockIndex[blockhash];
-
-        return (pblockindex->GetBlockTime() + nDeadline < currentTime);
+        if (fState == ACCEPTED && mapBlockIndex.count(blockhash) > 0) {
+            CBlockIndex* pblockindex = mapBlockIndex[blockhash];
+            return (pblockindex->GetBlockTime() + nDeadline < currentTime);
+        }
+        return (nVotingCycle > Params().GetConsensus().nCyclesProposalVoting && (CanVote() || fState == EXPIRED));
     } else {
         return (nDeadline < currentTime);
     }


### PR DESCRIPTION
Assigning `prequest.blockhash` to proposals in e8eaddbbc69eb6ba956c21ff934c06eca71f3f8d resulted in expiring proposals having an `fState == EXPIRED` and a valid `prequest.blockhash` that could be found in the blockchain.

In this case, when checking proposal state with `IsExpired()`, the logic skipped straight to checking proposal expiry based on its `nDeadline`.
This resulted in a bug where the proposal status went from ` 'status': 'expired waiting for end of voting period', 'state': 0` to `'status': 'pending', 'state': 3` instead of `'status': 'expired', 'state': 3` (see NAVCoin/navcoin-core#303)

I fixed this by only performing `nDeadline` based checking if the proposal was flagged as accepted (`fState == ACCEPTED`) and had a valid blockhash.
Otherwise the default voting cycle based expiry check is performed.

