### PR TITLE
Tweaks to the cfund gui

### DIFF
--- a/src/qt/forms/cfund_voting.cpp
+++ b/src/qt/forms/cfund_voting.cpp
@@ -130,7 +130,9 @@ void CFund_Voting::Refresh()
     ui->votingyesList->clear();
     ui->notvotingList->clear();
     ui->switchBtn->setText(fSettings ? tr("Switch to Proposal View") : tr("Switch to Payment Request View"));
+    ui->viewdetailsBtn->setText(fSettings ? tr("View Payment Request Details") : tr("View Proposal Details"));
     ui->windowMainTitle->setText(fSettings ? tr("Payment Request Voting") : tr("Proposal Voting"));
+
     enableDisableButtons();
 
     if (!fSettings)

--- a/src/qt/forms/cfund_voting.cpp
+++ b/src/qt/forms/cfund_voting.cpp
@@ -36,6 +36,7 @@ void CFund_Voting::voteYes() {
     } else {
         CFund::VotePaymentRequest(selected.toStdString(), true, d);
     }
+    setSelection("");
     Refresh();
 }
 
@@ -48,6 +49,7 @@ void CFund_Voting::voteNo() {
     } else {
         CFund::VotePaymentRequest(selected.toStdString(), false, d);
     }
+    setSelection("");
     Refresh();
 }
 
@@ -59,6 +61,7 @@ void CFund_Voting::stopVoting() {
     } else {
         CFund::RemoveVotePaymentRequest(selected.toStdString());
     }
+    setSelection("");
     Refresh();
 }
 
@@ -70,6 +73,7 @@ void CFund_Voting::viewDetails() {
 }
 
 void CFund_Voting::switchView() {
+    setSelection("");
     fSettings = !fSettings;
     Refresh();
 }
@@ -78,21 +82,41 @@ void CFund_Voting::selectedFromYes(QListWidgetItem* item) {
    ui->notvotingList->clearSelection();
    ui->votingnoList->clearSelection();
 
-   selected = item->data(1).toString();;
+   setSelection(item->data(1).toString());
 }
 
 void CFund_Voting::selectedFromNo(QListWidgetItem* item) {
    ui->notvotingList->clearSelection();
    ui->votingyesList->clearSelection();
 
-   selected = item->data(1).toString();
+   setSelection(item->data(1).toString());
 }
 
 void CFund_Voting::selectedFromNotVoting(QListWidgetItem* item) {
     ui->votingnoList->clearSelection();
     ui->votingyesList->clearSelection();
 
-    selected = item->data(1).toString();
+    setSelection(item->data(1).toString());
+}
+
+void CFund_Voting::setSelection(String selection) {
+    selected = selection;
+    enableDisableButtons();
+}
+
+void CFund_Voting::enableDisableButtons() {
+
+    if(selected == "") {
+        ui->voteyesBtn.setEnabled(false);
+        ui->votenoBtn.setEnabled(false);
+        ui->stopvotingBtn.setEnabled(false);
+        ui->viewdetailsBtn.setEnabled(false);
+    } else {
+        ui->voteyesBtn.setEnabled(true);
+        ui->votenoBtn.setEnabled(true);
+        ui->stopvotingBtn.setEnabled(true);
+        ui->viewdetailsBtn.setEnabled(true);
+    }
 }
 
 void CFund_Voting::Refresh()
@@ -102,7 +126,10 @@ void CFund_Voting::Refresh()
     ui->votingnoList->clear();
     ui->votingyesList->clear();
     ui->notvotingList->clear();
-    ui->switchBtn->setText(fSettings ? tr("Switch to Proposals") : tr("Switch to Payment Requests"));
+    ui->switchBtn->setText(fSettings ? tr("Switch to Proposal View") : tr("Switch to Payment Request View"));
+    ui->windowMainTitle->setText(fSettings ? tr("Payment Request Voting") : tr("Proposal Voting"));
+    enableDisableButtons();
+
     if (!fSettings)
     {
         std::vector<CFund::CProposal> vec;

--- a/src/qt/forms/cfund_voting.cpp
+++ b/src/qt/forms/cfund_voting.cpp
@@ -99,7 +99,7 @@ void CFund_Voting::selectedFromNotVoting(QListWidgetItem* item) {
     setSelection(item->data(1).toString());
 }
 
-void CFund_Voting::setSelection(String selection) {
+void CFund_Voting::setSelection(QString selection) {
     selected = selection;
     enableDisableButtons();
 }
@@ -107,15 +107,15 @@ void CFund_Voting::setSelection(String selection) {
 void CFund_Voting::enableDisableButtons() {
 
     if(selected == "") {
-        ui->voteyesBtn.setEnabled(false);
-        ui->votenoBtn.setEnabled(false);
-        ui->stopvotingBtn.setEnabled(false);
-        ui->viewdetailsBtn.setEnabled(false);
+        ui->voteyesBtn->setEnabled(false);
+        ui->votenoBtn->setEnabled(false);
+        ui->stopvotingBtn->setEnabled(false);
+        ui->viewdetailsBtn->setEnabled(false);
     } else {
-        ui->voteyesBtn.setEnabled(true);
-        ui->votenoBtn.setEnabled(true);
-        ui->stopvotingBtn.setEnabled(true);
-        ui->viewdetailsBtn.setEnabled(true);
+        ui->voteyesBtn->setEnabled(true);
+        ui->votenoBtn->setEnabled(true);
+        ui->stopvotingBtn->setEnabled(true);
+        ui->viewdetailsBtn->setEnabled(true);
     }
 }
 

--- a/src/qt/forms/cfund_voting.cpp
+++ b/src/qt/forms/cfund_voting.cpp
@@ -83,6 +83,7 @@ void CFund_Voting::selectedFromYes(QListWidgetItem* item) {
    ui->votingnoList->clearSelection();
 
    setSelection(item->data(1).toString());
+   ui->voteyesBtn->setEnabled(false);
 }
 
 void CFund_Voting::selectedFromNo(QListWidgetItem* item) {
@@ -90,6 +91,7 @@ void CFund_Voting::selectedFromNo(QListWidgetItem* item) {
    ui->votingyesList->clearSelection();
 
    setSelection(item->data(1).toString());
+   ui->votenoBtn->setEnabled(false);
 }
 
 void CFund_Voting::selectedFromNotVoting(QListWidgetItem* item) {
@@ -97,6 +99,7 @@ void CFund_Voting::selectedFromNotVoting(QListWidgetItem* item) {
     ui->votingyesList->clearSelection();
 
     setSelection(item->data(1).toString());
+    ui->stopvotingBtn->setEnabled(false);
 }
 
 void CFund_Voting::setSelection(QString selection) {
@@ -112,10 +115,10 @@ void CFund_Voting::enableDisableButtons() {
         ui->stopvotingBtn->setEnabled(false);
         ui->viewdetailsBtn->setEnabled(false);
     } else {
-        ui->voteyesBtn->setEnabled(true);
+        ui->viewdetailsBtn->setEnabled(true);
+        ui->votingyesListui->voteyesBtn->setEnabled(true);
         ui->votenoBtn->setEnabled(true);
         ui->stopvotingBtn->setEnabled(true);
-        ui->viewdetailsBtn->setEnabled(true);
     }
 }
 

--- a/src/qt/forms/cfund_voting.cpp
+++ b/src/qt/forms/cfund_voting.cpp
@@ -116,7 +116,7 @@ void CFund_Voting::enableDisableButtons() {
         ui->viewdetailsBtn->setEnabled(false);
     } else {
         ui->viewdetailsBtn->setEnabled(true);
-        ui->votingyesListui->voteyesBtn->setEnabled(true);
+        ui->voteyesBtn->setEnabled(true);
         ui->votenoBtn->setEnabled(true);
         ui->stopvotingBtn->setEnabled(true);
     }

--- a/src/qt/forms/cfund_voting.h
+++ b/src/qt/forms/cfund_voting.h
@@ -32,6 +32,8 @@ public Q_SLOTS:
     void selectedFromYes(QListWidgetItem* item);
     void selectedFromNo(QListWidgetItem* item);
     void selectedFromNotVoting(QListWidgetItem* item);
+    void enableDisableButtons();
+    void setSelection(QString selection);
 
 private:
     Ui::CFund_Voting *ui;

--- a/src/qt/forms/cfund_voting.ui
+++ b/src/qt/forms/cfund_voting.ui
@@ -15,9 +15,9 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
-      <spacer name="horizontalSpacer_3">
+      <spacer name="horizontalSpacer_5">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
@@ -30,11 +30,30 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="switchBtn">
+      <widget class="QLabel" name="windowMainTitle">
+       <property name="font">
+        <font>
+         <family>.PingFang TC</family>
+         <pointsize>18</pointsize>
+        </font>
+       </property>
        <property name="text">
-        <string>Switch to Payment Requests</string>
+        <string>Proposal Voting</string>
        </property>
       </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_6">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
      </item>
     </layout>
    </item>
@@ -43,7 +62,7 @@
      <item>
       <widget class="QLabel" name="label_3">
        <property name="text">
-        <string>New pending review:</string>
+        <string>No vote selected:</string>
        </property>
       </widget>
      </item>
@@ -53,7 +72,7 @@
      <item>
       <widget class="QLabel" name="label">
        <property name="text">
-        <string>Supporting:</string>
+        <string>Voting for:</string>
        </property>
       </widget>
      </item>
@@ -63,7 +82,7 @@
      <item>
       <widget class="QLabel" name="label_2">
        <property name="text">
-        <string>Rejecting:</string>
+        <string>Voting against:</string>
        </property>
       </widget>
      </item>
@@ -76,8 +95,11 @@
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QPushButton" name="viewdetailsBtn">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
        <property name="text">
-        <string>View Details</string>
+        <string>View Proposal Details</string>
        </property>
       </widget>
      </item>
@@ -95,7 +117,20 @@
       </spacer>
      </item>
      <item>
+      <widget class="QPushButton" name="stopvotingBtn">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Stop Voting</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="voteyesBtn">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
        <property name="text">
         <string>Vote Yes</string>
        </property>
@@ -103,20 +138,27 @@
      </item>
      <item>
       <widget class="QPushButton" name="votenoBtn">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
        <property name="text">
         <string>Vote No</string>
        </property>
       </widget>
      </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
-      <widget class="QPushButton" name="stopvotingBtn">
+      <widget class="QPushButton" name="switchBtn">
        <property name="text">
-        <string>Stop Voting</string>
+        <string>Switch to Payment Request View</string>
        </property>
       </widget>
      </item>
      <item>
-      <spacer name="horizontalSpacer_2">
+      <spacer name="horizontalSpacer_3">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>822</width>
-    <height>674</height>
+    <height>690</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -499,7 +499,7 @@
           <string notr="true">color:#cc2222</string>
          </property>
          <property name="text">
-          <string>Wallet syncing, the balance won't be accurate until the process finishes</string>
+          <string>This wallet is currently syncing. Your balance may not be accurate until it has completed</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>

--- a/src/qt/navcoingui.cpp
+++ b/src/qt/navcoingui.cpp
@@ -149,7 +149,7 @@ NavCoinGUI::NavCoinGUI(const PlatformStyle *platformStyle, const NetworkStyle *n
     helpMessageDialog(0),
     prevBlocks(0),
     spinnerFrame(0),
-    fNotShowAgain(false),
+    fDontShowAgain(false),
     lastDialogShown(0),
     unlockWalletAction(0),
     lockWalletAction(0),
@@ -426,8 +426,8 @@ void NavCoinGUI::createActions()
     optionsAction->setStatusTip(tr("Modify configuration options for %1").arg(tr(PACKAGE_NAME)));
     optionsAction->setMenuRole(QAction::PreferencesRole);
     optionsAction->setEnabled(false);
-    cfundProposalsAction = new QAction(tr("Voting of Proposals"), this);
-    cfundPaymentRequestsAction = new QAction(tr("Voting of Payment Requests"), this);
+    cfundProposalsAction = new QAction(tr("Vote for Proposals"), this);
+    cfundPaymentRequestsAction = new QAction(tr("Vote for Payment Requests"), this);
     toggleHideAction = new QAction(platformStyle->TextColorIcon(":/icons/about"), tr("&Show / Hide"), this);
     toggleHideAction->setStatusTip(tr("Show or hide the main Window"));
 
@@ -1827,10 +1827,10 @@ void NavCoinGUI::updateStakingStatus()
                     }
                 }
             }
-            if (fFound && !this->fNotShowAgain && (this->lastDialogShown + (60*60*24)) < GetTimeNow()) {
-                QCheckBox *cb = new QCheckBox("Do not show this message again during this session.");
+            if (fFound && !this->fDontShowAgain && (this->lastDialogShown + (60*60*24)) < GetTimeNow()) {
+                QCheckBox *cb = new QCheckBox("Don't show this notification again until wallet is restarted.");
                 QMessageBox msgbox;
-                msgbox.setText(tr("There are new proposals or payment requests from the Community Fund.<br><br>As a staker it's very important you engadge in the voting process.<br><br>Please cast your vote using the voting dialog!"));
+                msgbox.setText(tr("There are new proposals or payment requests from the Community Fund.<br><br>As a staker it's very important you engage in the voting process.<br><br>Please cast your vote using the voting dialog!"));
                 msgbox.setIcon(QMessageBox::Icon::Warning);
                 msgbox.setCheckBox(cb);
                 QAbstractButton* pButtonInfo = msgbox.addButton(tr("Read about the Community Fund"), QMessageBox::YesRole);
@@ -1840,9 +1840,9 @@ void NavCoinGUI::updateStakingStatus()
                 msgbox.exec();
 
                 if(cb->isChecked()) {
-                    this->fNotShowAgain = true;
+                    this->fDontShowAgain = true;
                 } else {
-                    this->fNotShowAgain = false;
+                    this->fDontShowAgain = false;
                 }
 
                 if (msgbox.clickedButton()==pButtonOpen) {

--- a/src/qt/navcoingui.h
+++ b/src/qt/navcoingui.h
@@ -145,7 +145,7 @@ private:
     int prevBlocks;
     int spinnerFrame;
 
-    bool fNotShowAgain;
+    bool fDontShowAgain;
     int64_t lastDialogShown;
 
     uint64_t nWeight;


### PR DESCRIPTION
# Changes

- Fixed some spelling and wording
- Added a new title to the dialog so we can see easily if we are looking at proposals or payment requests. 
- Moved some buttons around for a cleaner gui
- Buttons (Vote yes, vote no, removed vote, view proposal) are disabled unless a proposal is selected
- Buttons are disabled if a proposal is already in their category (if we are voting no on a proposal when we select it the 'vote no' button is disabled)
- we now deselect proposals properly after changing view or changing their vote

### Preview:

<img width="644" alt="image" src="https://user-images.githubusercontent.com/12672050/49581094-afe1ae80-f9b5-11e8-9831-8cf8f82b2d13.png">
