### PR TITLE
Adds assert after try blocks and checks for preq creation in new state

### DIFF
--- a/qa/rpc-tests/cfund-paymentrequest-state-accept-expired-proposal.py
+++ b/qa/rpc-tests/cfund-paymentrequest-state-accept-expired-proposal.py
@@ -135,7 +135,7 @@ class CommunityFundPaymentRequestsTest(NavCoinTestFramework):
         assert(self.nodes[0].getpaymentrequest(paymentrequestid0)["status"] == "pending")
         assert(self.nodes[0].cfundstats()["funds"]["locked"] == locked_accepted)
 
-        assert(self.nodes[0].getproposal(proposalid0)["status"] == "expired waiting for end of voting period")
+        assert(self.nodes[0].getproposal(proposalid0)["status"] == "expired pending voting of payment requests")
 
         # Vote enough quorum and enough positive votes
 

--- a/qa/rpc-tests/cfund-paymentrequest-state-accept-expired-proposal.py
+++ b/qa/rpc-tests/cfund-paymentrequest-state-accept-expired-proposal.py
@@ -75,6 +75,15 @@ class CommunityFundPaymentRequestsTest(NavCoinTestFramework):
         end_cycle(self.nodes[0])
         slow_gen(self.nodes[0], 1)
 
+        # No more payment requests are allowed as the proposal deadline has passed
+        payment_request_not_created = True
+        try:
+            paymentrequestid1 = self.nodes[0].createpaymentrequest(proposalid0, 2, "test1")["hash"]
+            payment_request_not_created = False
+        except JSONRPCException:
+            pass
+        assert(payment_request_not_created)
+
         # Vote enough yes votes, without enough quorum
 
         total_votes = self.nodes[0].cfundstats()["consensus"]["minSumVotesPerVotingCycle"]
@@ -175,10 +184,13 @@ class CommunityFundPaymentRequestsTest(NavCoinTestFramework):
         assert(self.nodes[0].getproposal(proposalid0)["status"] == "expired")
 
         # No more payment requests are allowed as the proposal is expired
+        payment_request_not_created = True
         try:
-            paymentrequestid1 = self.nodes[0].createpaymentrequest(proposalid0, 2, "test3")["hash"]
+            paymentrequestid2 = self.nodes[0].createpaymentrequest(proposalid0, 2, "test2")["hash"]
+            payment_request_not_created = False
         except JSONRPCException:
             pass
+        assert(payment_request_not_created)
 
 if __name__ == '__main__':
     CommunityFundPaymentRequestsTest().main()

--- a/src/consensus/cfund.cpp
+++ b/src/consensus/cfund.cpp
@@ -390,7 +390,7 @@ bool CFund::CProposal::IsExpired(uint32_t currentTime) const {
             CBlockIndex* pblockindex = mapBlockIndex[blockhash];
             return (pblockindex->GetBlockTime() + nDeadline < currentTime);
         }
-        return (fState == EXPIRED) || (nVotingCycle > Params().GetConsensus().nCyclesProposalVoting && (CanVote() || fState == EXPIRED));
+        return (fState == EXPIRED) || (fState == PENDING_VOTING_PREQ) || (nVotingCycle > Params().GetConsensus().nCyclesProposalVoting && (CanVote() || fState == EXPIRED));
     } else {
         return (nDeadline < currentTime);
     }

--- a/src/consensus/cfund.h
+++ b/src/consensus/cfund.h
@@ -246,6 +246,9 @@ public:
             if(fState != EXPIRED)
                 sFlags += " waiting for end of voting period";
         }
+        if(fState == PENDING_VOTING_PREQ) {
+            sFlags = "expired pending voting of payment requests";
+        }
         return sFlags;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4063,6 +4063,7 @@ void CountVotes(CValidationState& state, CBlockIndex *pindexNew, bool fUndo)
                     if (proposal.fState != CFund::EXPIRED) {
                         if (proposal.HasPendingPaymentRequests()) {
                             proposal.fState = CFund::PENDING_VOTING_PREQ;
+                            fUpdate = true;
                         } else {
                             if(proposal.fState == CFund::ACCEPTED || proposal.fState == CFund::PENDING_VOTING_PREQ) {
                                 pindexNew->nCFSupply += proposal.GetAvailable();


### PR DESCRIPTION
This PR modifies the expired state tests:

- Adds assert to check that try blocks do not complete when they contain code expected to fail
- Checks payment requests cannot be made during the new expired-but-pending state 
- Trivial fixes to variable names/numbering