### PR TITLE
fixes qt transaction display for -stakingaddress feature

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -55,6 +55,11 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
         // Credit
         //
         unsigned int i = 0;
+        unsigned int rewardIdx = 0;
+        if (wtx.IsCoinStake())
+            // If coinstake has no cfund contribution, get details of last vout or else use second to last
+            rewardIdx = wtx.vout.size() - (wtx.GetValueOutCFund() == 0 ? 1 : 2);
+
         BOOST_FOREACH(const CTxOut& txout, wtx.vout)
         {
             isminetype mine = wallet->IsMine(txout);
@@ -88,10 +93,10 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                 {
                     // Generated (proof-of-stake)
 
-                    if (i != wtx.vout.size() - 1)
+                    if (i != rewardIdx)
                     {
                         i++;
-                        continue; // only append details of the last coinstake output
+                        continue; // only append details of the address with reward output
                     }
 
                     sub.type = TransactionRecord::Staked;

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -40,7 +40,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
     CAmount nDebit = wtx.GetDebit((wtx.IsCoinStake() && wtx.vout[1].scriptPubKey.IsColdStaking()) ? ISMINE_STAKABLE : ISMINE_ALL);
     CAmount nCFundCredit = wtx.GetDebit(ISMINE_ALL);
     CAmount nNet = nCredit - nDebit;
-    uint256 hash = wtx.GetHash(), hashPrev = uint256();
+    uint256 hash = wtx.GetHash();
     std::map<std::string, std::string> mapValue = wtx.mapValue;
     std::string dzeel = "";
 
@@ -88,12 +88,14 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                 {
                     // Generated (proof-of-stake)
 
-                    if (hashPrev == hash)
-                        continue; // last coinstake output
+                    if (i != wtx.vout.size() - 1)
+                    {
+                        i++;
+                        continue; // only append details of the last coinstake output
+                    }
 
                     sub.type = TransactionRecord::Staked;
                     sub.credit = nNet > 0 ? nNet : wtx.GetValueOut() - nDebit - wtx.GetValueOutCFund();
-                    hashPrev = hash;
                 }
                 if(wtx.fAnon)
                 {


### PR DESCRIPTION
Previously when using `-stakingaddress`, the wallet display for a staking reward would show the vin address instead of the receiving address because `decomposeTransaction()` only records the first vout address of a coinstaking tx:
![51505226-3c530e00-1e4a-11e9-9be7-6812face4ff9](https://user-images.githubusercontent.com/36244342/52611092-b9712080-2ee8-11e9-8bab-2c3cc5708313.png)

This PR changes `decomposeTransaction()` to record the address of the last vout instead, which is compatible with stakes using `-stakingaddress` and without.

Also removes `hashprev` variable which is no longer used.